### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Osiris Pipeline v0.1.0 - Conversational ETL Pipeline Generator
+# Osiris Pipeline v0.2.0 - Conversational ETL Pipeline Generator
 
 **MVP**: Basic conversational ETL pipeline generation using AI. Simple proof-of-concept implementation.
 

--- a/osiris/cli/main.py
+++ b/osiris/cli/main.py
@@ -12,7 +12,7 @@
 # # See the License for the specific language governing permissions and
 # # limitations under the License.
 
-"""Main CLI entry point for Osiris v2."""
+"""Main CLI entry point for Osiris."""
 
 import argparse
 import contextlib
@@ -41,7 +41,7 @@ def show_main_help():
 
     console.print()
     console.print(
-        "[bold green]Osiris v2 - Autonomous AI Agent for Reliable Data Pipelines.[/bold green]"
+        "[bold green]Osiris v0.2.0 - LLM-first Conversational ETL Pipeline Generator[/bold green]"
     )
     console.print("🤖 Your AI data engineering buddy that discovers, analyzes, and executes")
     console.print("production-ready ETL pipelines through natural conversation.")
@@ -132,7 +132,7 @@ def parse_main_args():
 
     # Parse global arguments
     parser = argparse.ArgumentParser(
-        description="Osiris v2 - Autonomous AI Agent for Reliable Data Pipelines",
+        description="Osiris v0.2.0 - LLM-first Conversational ETL Pipeline Generator",
         add_help=False,
         prog="osiris.py",
     )
@@ -188,9 +188,9 @@ def main():
 
     if args.version:
         if json_output:
-            print(json.dumps({"version": "v2.0.0-mvp"}))
+            print(json.dumps({"version": "v0.2.0"}))
         else:
-            console.print("Osiris v2.0.0-mvp")
+            console.print("Osiris v0.2.0")
         return
 
     # Handle commands first, then help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "osiris-pipeline"
-version = "0.1.1"
+version = "0.2.0"
 description = "LLM-first conversational ETL pipeline generator"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary
Bump version to 0.2.0 after successfully merging Milestone M1 (PR #14).

## Changes
- **pyproject.toml**: `version = "0.2.0"`
- **README.md**: Updated header to `v0.2.0`
- **osiris/cli/main.py**: Updated CLI version from `v2.0.0-mvp` to `v0.2.0`

## Verification
```bash
$ python osiris.py --version
Osiris v0.2.0
```

## Next Steps
After merging this PR:
1. Tag the release: `git tag v0.2.0 && git push --tags`
2. Create GitHub Release from CHANGELOG v0.2.0 section